### PR TITLE
docs: fix badge URL format to use shields.io endpoint wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,26 +275,28 @@ Get live deployment status badges for your repositories:
 
 ### Badge Format
 
+The deploy-mcp.io endpoint returns JSON data for shields.io. Use the shields.io endpoint wrapper:
+
 ```markdown
-![Platform Deployment](https://deploy-mcp.io/badge/{username}/{repository}/{platform})
+![Platform Deployment](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/{username}/{repository}/{platform})
 ```
 
 ### Examples by Platform
 
 #### Vercel Badge
 ```markdown
-![Vercel](https://deploy-mcp.io/badge/john/my-app/vercel)
+![Vercel](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/john/my-app/vercel)
 ```
 
 #### Netlify Badge
 ```markdown
-![Netlify](https://deploy-mcp.io/badge/john/my-app/netlify)
+![Netlify](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/john/my-app/netlify)
 ```
 
 #### Multiple Badges
 ```markdown
-![Vercel](https://deploy-mcp.io/badge/john/my-app/vercel)
-![Netlify](https://deploy-mcp.io/badge/john/my-app/netlify)
+![Vercel](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/john/my-app/vercel)
+![Netlify](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/john/my-app/netlify)
 ```
 
 ### Webhook Configuration

--- a/src/landing-page.ts
+++ b/src/landing-page.ts
@@ -692,7 +692,7 @@ export const landingPageHTML = `<!DOCTYPE html>
         </div>
 
         <div class="badge-code">
-          <code>![Deploy Status](https://deploy-mcp.io/badge/{user}/{repo}/{platform})</code>
+          <code>![Deploy Status](https://img.shields.io/endpoint?url=https://deploy-mcp.io/badge/{user}/{repo}/{platform})</code>
         </div>
 
         <p style="margin-top: 24px; font-size: 14px; color: var(--text-dim);">


### PR DESCRIPTION
- Update README badge examples to use img.shields.io/endpoint wrapper
- Update landing page badge format to match correct implementation
- Add explanation that deploy-mcp.io returns JSON data for shields.io

The deploy-mcp.io endpoint returns JSON data, not a direct image. Users must wrap the URL with img.shields.io/endpoint to render badges.